### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -12,7 +12,7 @@
     ],
     "sharedGlobals": ["{workspaceRoot}/.github/workflows/ci.yml"]
   },
-  "nxCloudId": "687142d184087b42d7561f08",
+  "nxCloudId": "687fa1a39da31a8b34f9bc6e",
   "targetDefaults": {
     "@angular/build:application": {
       "cache": true,

--- a/nx.json
+++ b/nx.json
@@ -12,7 +12,7 @@
     ],
     "sharedGlobals": ["{workspaceRoot}/.github/workflows/ci.yml"]
   },
-  "nxCloudId": "6871428f1032191a3cc32b7e",
+  "nxCloudId": "687142d184087b42d7561f08",
   "targetDefaults": {
     "@angular/build:application": {
       "cache": true,
@@ -28,10 +28,7 @@
         "{workspaceRoot}/eslint.config.mjs"
       ]
     },
-    "@nx/vite:test": {
-      "cache": true,
-      "inputs": ["default", "^production"]
-    }
+    "@nx/vite:test": { "cache": true, "inputs": ["default", "^production"] }
   },
   "generators": {
     "@nx/angular:application": {
@@ -40,5 +37,6 @@
       "style": "css",
       "unitTestRunner": "vitest"
     }
-  }
+  },
+  "nxCloudUrl": "https://snapshot.nx.app"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://snapshot.nx.app/orgs/687142c76b7df4d5015750e6/workspaces/687142d184087b42d7561f08

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.